### PR TITLE
Implement sliding window without scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+.ensime*
 .idea
-target
+.sbt-launch.jar
+
+ensime-langserver.log
+pc.stdout.log
+
+target/

--- a/src/main/scala/io/buoyant/linkerd/RateLimiter.scala
+++ b/src/main/scala/io/buoyant/linkerd/RateLimiter.scala
@@ -1,26 +1,29 @@
 package io.buoyant.linkerd
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.http.{Request, Response, Status}
-import com.twitter.util.{Duration, Future, Timer}
+import com.twitter.util.{Duration, Future, Time}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.IntUnaryOperator
 
-class RateLimiter(limit: Int, timer: Timer, intervalSecs: Duration) extends SimpleFilter[Request, Response] {
+class RateLimiter(limit: Int, windowSecs: Duration) extends SimpleFilter[Request, Response] {
   private[this] val count = new AtomicInteger()
-  private[this] val decrementToZero: IntUnaryOperator = i => if (i > 0) i - 1 else i
-  private[this] val period = intervalSecs / limit
-
-  timer.schedule(period)(count.getAndUpdate(decrementToZero))
+  private[this] var lastReset = Time.epoch
 
   override def apply(
     request: Request,
     service: Service[Request, Response]
   ): Future[Response] = {
-    if (count.get() >= limit) Future.value(Response(Status.TooManyRequests))
-    else {
-      count.getAndIncrement()
+    if (lastReset.untilNow >= windowSecs) {
+      count.set(limit)
+      lastReset = Time.now
+    }
+    
+    if (count.getAndDecrement > 0) {
       service(request)
+    } else {
+      Future.value(Response(Status.TooManyRequests))
     }
   }
 }

--- a/src/main/scala/io/buoyant/linkerd/RateLimiterConfig.scala
+++ b/src/main/scala/io/buoyant/linkerd/RateLimiterConfig.scala
@@ -3,13 +3,12 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Filter, Stack}
 import io.buoyant.linkerd.protocol.HttpRequestAuthorizerConfig
 
-class RateLimiterConfig(limit: Int, intervalSecs: Int = 1) extends HttpRequestAuthorizerConfig{
+class RateLimiterConfig(limit: Int, windowSecs: Int = 1) extends HttpRequestAuthorizerConfig{
   require(limit > 0, "The request limit must be greater than 0 requests.")
-  require(intervalSecs > 0, "The interval must be greater than 0 seconds.")
+  require(windowSecs > 0, "The window must be greater than 0 seconds.")
 
   @JsonIgnore
   override def role: Stack.Role = Stack.Role("HttpRateLimiter")
@@ -22,6 +21,6 @@ class RateLimiterConfig(limit: Int, intervalSecs: Int = 1) extends HttpRequestAu
 
   @JsonIgnore
   override def mk(params: Stack.Params): Filter[Request, Response, Request, Response] = {
-    new RateLimiter(limit, DefaultTimer, intervalSecs.seconds)
+    new RateLimiter(limit, windowSecs.seconds)
   }
 }

--- a/src/main/scala/io/buoyant/linkerd/RateLimiterInitializer.scala
+++ b/src/main/scala/io/buoyant/linkerd/RateLimiterInitializer.scala
@@ -2,7 +2,6 @@ package io.buoyant.linkerd
 
 class RateLimiterInitializer extends RequestAuthorizerInitializer {
   val configClass: Class[_] = classOf[RateLimiterConfig]
-
   override val configId: String = "io.l5d.rateLimiter"
 }
 


### PR DESCRIPTION
This new implementation addresses two issues brought up with the first
implementation.

1. The rate limit is enforced from the start of the first window, as
well as windows where no requests were sent in the previous window.

2. High rate limits will not be hindered by interrupts from the count
being decremented each period.

Also, ignore some Ensime things because it is stable enough for common use now!